### PR TITLE
Fix weapon skin loading issue

### DIFF
--- a/final.sp
+++ b/final.sp
@@ -2807,9 +2807,16 @@ bool:Menu_ShowWeapon(client, const String:weapon[], const String:title[])
 				new selected_skin = 0;
 				new bool:has_skin = ParseCookieValue(sUserValue, model_name, sizeof(model_name), selected_skin);
 				
-				if (has_skin && StrEqual(section, model_name))
+				if ((has_skin && StrEqual(section, model_name)) || (!has_skin && StrEqual(section, sUserValue)))
 				{
-					Format(buffer, sizeof(buffer), "%s (Skin %d) [+]", buffer, selected_skin);
+					if (has_skin)
+					{
+						Format(buffer, sizeof(buffer), "%s (Skin %d) [+]", buffer, selected_skin);
+					}
+					else
+					{
+						StrCat(buffer, sizeof(buffer), " [+]");
+					}
 					AddMenuItem(menu, section, buffer, has_access ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
 					continue;
 				}
@@ -2897,23 +2904,23 @@ public WeaponMenu_Handler(Handle:menu, MenuAction:action, param1, param2)
 			
 			// Check if this is a multi-skin model
 			decl String:model_name[64];
-			new selected_skin = 0;
-			new bool:has_skin = ParseCookieValue(sInfo, model_name, sizeof(model_name), selected_skin);
+			strcopy(model_name, sizeof(model_name), sInfo);
 			
 			if (KvJumpToKey(hKv, szWeapon[param1]) && KvJumpToKey(hKv, model_name))
 			{
 				new max_skin = KvGetNum(hKv, "max_skin", 0);
-				KvRewind(hKv);
 				
 				if (max_skin > 0)
 				{
 					// Show skin selection menu
+					KvRewind(hKv);
 					if (!Menu_ShowSkinSelection(param1, model_name, max_skin))
 					{
 						Menu_ShowWeapon(param1, szWeapon[param1], sTitle[param1]);
 					}
 					return;
 				}
+				KvRewind(hKv);
 			}
 			
 			// Single skin model or default selection


### PR DESCRIPTION
Fixes incorrect model loading and menu selection for weapons with multiple skins.

The `WeaponMenu_Handler` was incorrectly attempting to parse the selected model name as a cookie value, preventing proper identification of multi-skin models. Additionally, the `KvRewind` call was misplaced, leading to incorrect KeyValues navigation. The `Menu_ShowWeapon` selection logic was also updated to correctly highlight models chosen without a specific skin.

---
<a href="https://cursor.com/background-agent?bcId=bc-023f7b50-9ca0-4afa-9bd7-28bf7442d304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-023f7b50-9ca0-4afa-9bd7-28bf7442d304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>