### PR TITLE
Fix weapon skin loading issue

### DIFF
--- a/final.sp
+++ b/final.sp
@@ -930,6 +930,10 @@ bool:ParseCookieValue(const String:cookie_value[], String:model_name[], model_si
 				decl String:skin_str[8];
 				strcopy(skin_str, sizeof(skin_str), cookie_value[pos + 1]);
 				skin_index = StringToInt(skin_str);
+				// Clamp to valid Source engine range (0-15) to prevent fallback to default models
+				if (skin_index > 15) {
+					skin_index = skin_index % 16;
+				}
 				return true;
 			}
 		}
@@ -1464,8 +1468,7 @@ public OnPostThinkPost_Old(client)
 		OldWeapon[client] = WeaponIndex;
 		return;
 	}
-	else
-	if (IsCustom[client])
+	else if (IsCustom[client])
 	{
 		if (g_bDev[client])
 		{
@@ -1650,8 +1653,7 @@ public OnPostThinkPost(client)
 		OldWeapon[client] = WeaponIndex;
 		return;
 	}
-	else
-	if (IsCustom[client])
+	else if (IsCustom[client])
 	{
 		switch (Function_OnWeaponThink(hPlugin[client], weapon_sequence[client], client, WeaponIndex, ClientVM[client], ClientVM[client], OldSequence[client], Sequence))
 		{
@@ -2005,6 +2007,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 									index = KvGetNum(hKv, "view_model_index");
 									// Use selected skin if available, otherwise use default
 									skin_index = has_skin ? selected_skin : KvGetNum(hKv, "skin_index", 0);
+									// CLAMP
+									if (skin_index > 15) {
+										skin_index = skin_index % 16;
+									}
 									world_model = KvGetNum(hKv, "world_model_index");
 									
 									g_bMuzzleFlash[client] = bool:KvGetNum(hKv, "muzzle_flash", false);
@@ -2037,6 +2043,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 						index = KvGetNum(hKv, "view_model_index");
 						// Use selected skin if available, otherwise use default
 						skin_index = has_skin ? selected_skin : KvGetNum(hKv, "skin_index", 0);
+						// CLAMP
+						if (skin_index > 15) {
+							skin_index = skin_index % 16;
+						}
 						world_model = KvGetNum(hKv, "world_model_index");
 						
 						g_bMuzzleFlash[client] = bool:KvGetNum(hKv, "muzzle_flash", false);
@@ -2288,6 +2298,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 								index = KvGetNum(hKv, "view_model_index");
 								// Use selected skin if available, otherwise use default
 								skin_index = has_skin ? selected_skin : KvGetNum(hKv, "skin_index", 0);
+								// CLAMP
+								if (skin_index > 15) {
+									skin_index = skin_index % 16;
+								}
 								world_model = KvGetNum(hKv, "world_model_index");
 								dropped_model = KvGetNum(hKv, "drop_model_index");
 								
@@ -2327,6 +2341,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 					index = KvGetNum(hKv, "view_model_index");
 					// Use selected skin if available, otherwise use default
 					skin_index = has_skin ? selected_skin : KvGetNum(hKv, "skin_index", 0);
+					// CLAMP
+					if (skin_index > 15) {
+						skin_index = skin_index % 16;
+					}
 					world_model = KvGetNum(hKv, "world_model_index");
 					dropped_model = KvGetNum(hKv, "drop_model_index");
 					


### PR DESCRIPTION
Clamp weapon skin indices to the valid Source engine range (0-15) to prevent models from reverting to default.

The Source engine's `m_nSkin` network property uses only 4 bits, effectively limiting usable skin indices to 0-15. Values greater than 15 are truncated to 0 by the engine, causing models to display their default texture. This change applies a modulo 16 operation to all calculated skin indices, ensuring they remain within the engine's supported range and allowing models with higher configured skin values to display correctly by cycling through the available 16 textures.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8996967-999c-4684-8a43-5733eda994a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8996967-999c-4684-8a43-5733eda994a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>