### PR TITLE
Fix custom weapon skin loading issue

### DIFF
--- a/picha2edit.sp
+++ b/picha2edit.sp
@@ -826,8 +826,10 @@ public OnClientDisconnect_Post(client)
 	weapon_switch[client] = INVALID_FUNCTION;
 	weapon_sequence[client] = INVALID_FUNCTION;
 	
-	ClearTrie(g_hTrieSounds[client][0]);
-	ClearTrie(g_hTrieSounds[client][1]);
+	if (g_hTrieSounds[client][0] != INVALID_HANDLE)
+		ClearTrie(g_hTrieSounds[client][0]);
+	if (g_hTrieSounds[client][1] != INVALID_HANDLE)
+		ClearTrie(g_hTrieSounds[client][1]);
 	ClearTrie(g_hTrieSequence[client]);
 	
 	for (new i = 0; i < 14; i++)
@@ -1433,8 +1435,10 @@ public OnPostThinkPost_Old(client)
 			iCycle[client] = 0;
 			next_cycle[client] = 0.0;
 			
-			ClearTrie(g_hTrieSounds[client][0]);
-			ClearTrie(g_hTrieSounds[client][1]);
+			if (g_hTrieSounds[client][0] != INVALID_HANDLE)
+				ClearTrie(g_hTrieSounds[client][0]);
+			if (g_hTrieSounds[client][1] != INVALID_HANDLE)
+				ClearTrie(g_hTrieSounds[client][1]);
 			ClearTrie(g_hTrieSequence[client]);
 			
 			for (new i = 0; i < 14; i++)
@@ -1607,12 +1611,14 @@ public OnPostThinkPost(client)
 			
 			OldSequence[client] = 0;
 	
-			iCycle[client] = 0;
-			next_cycle[client] = 0.0;
-			
+					iCycle[client] = 0;
+		next_cycle[client] = 0.0;
+		
+		if (g_hTrieSounds[client][0] != INVALID_HANDLE)
 			ClearTrie(g_hTrieSounds[client][0]);
+		if (g_hTrieSounds[client][1] != INVALID_HANDLE)
 			ClearTrie(g_hTrieSounds[client][1]);
-			ClearTrie(g_hTrieSequence[client]);
+		ClearTrie(g_hTrieSequence[client]);
 			
 			for (new i = 0; i < 14; i++)
 			{
@@ -1868,8 +1874,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 	// Винаги използваме два view model-а за всички версии освен CSGO
 	if (Engine_Version != GAME_CSGO)
 	{
-		ClearTrie(g_hTrieSounds[client][0]);
-		ClearTrie(g_hTrieSounds[client][1]);
+		if (g_hTrieSounds[client][0] != INVALID_HANDLE)
+			ClearTrie(g_hTrieSounds[client][0]);
+		if (g_hTrieSounds[client][1] != INVALID_HANDLE)
+			ClearTrie(g_hTrieSounds[client][1]);
 		ClearTrie(g_hTrieSequence[client]);
 		
 		for (new i = 0; i < 14; i++)
@@ -2163,8 +2171,10 @@ bool:OnWeaponChanged(client, WeaponIndex, Sequence, bool:really_change = false)
 		return result;
 	}
 	
-	ClearTrie(g_hTrieSounds[client][0]);
-	ClearTrie(g_hTrieSounds[client][1]);
+	if (g_hTrieSounds[client][0] != INVALID_HANDLE)
+		ClearTrie(g_hTrieSounds[client][0]);
+	if (g_hTrieSounds[client][1] != INVALID_HANDLE)
+		ClearTrie(g_hTrieSounds[client][1]);
 	ClearTrie(g_hTrieSequence[client]);
 	
 	for (new i = 0; i < 14; i++)


### PR DESCRIPTION
<pr_request_template>Add checks to `ClearTrie` calls for `g_hTrieSounds` to prevent errors from uninitialized handles.

Previously, `ClearTrie` was called on `g_hTrieSounds` handles without ensuring they were valid, leading to runtime errors. This issue manifested as only the first two weapon models loading correctly from the configuration, with subsequent models failing to load. Adding `INVALID_HANDLE` checks ensures that `ClearTrie` is only called on properly initialized handles, resolving the model loading problem.</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-4700fc84-8a7a-4843-9d91-974bfdf5987b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4700fc84-8a7a-4843-9d91-974bfdf5987b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>